### PR TITLE
Add basic web page with last updated timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ newest listing date.
 
 Before scraping any website, ensure that doing so complies with the
 website's terms of service.
+
+## GitHub Pages
+
+The contents of this repository are served on GitHub Pages at
+`https://<username>.github.io/shopnews3/`.
+
+GitHub Pages publishes straight from the `main` branch. To update the
+live site:
+
+1. Run `python feed.py` to scrape new listings and update `data.json`.
+2. Commit the updated files and push to `main`.
+3. GitHub Pages will automatically deploy the changes.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Needles Track Pants Feed</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    #error { color: red; }
+  </style>
+</head>
+<body>
+  <h1>Needles Track Pants Feed</h1>
+  <p id="last-updated"></p>
+  <ul id="feed"></ul>
+  <p id="error" style="display:none"></p>
+  <script>
+    async function loadFeed() {
+      const errorEl = document.getElementById('error');
+      const lastUpdatedEl = document.getElementById('last-updated');
+      const feedEl = document.getElementById('feed');
+      try {
+        const resp = await fetch('data.json');
+        if (!resp.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await resp.json();
+        if (data.length > 0) {
+          const lastUpdated = data.reduce((max, item) => {
+            return item.fetched_at && item.fetched_at > max ? item.fetched_at : max;
+          }, data[0].fetched_at || '');
+          lastUpdatedEl.textContent = 'Last updated: ' + (lastUpdated ? new Date(lastUpdated).toLocaleString() : 'n/a');
+          data.forEach(item => {
+            const li = document.createElement('li');
+            const price = item.price ? ` – ${item.price}` : '';
+            li.innerHTML = `<a href="${item.url}">${item.title}</a>${price}`;
+            feedEl.appendChild(li);
+          });
+        } else {
+          lastUpdatedEl.textContent = 'Last updated: n/a';
+          const li = document.createElement('li');
+          li.textContent = 'No items found';
+          feedEl.appendChild(li);
+        }
+      } catch (err) {
+        errorEl.textContent = 'Failed to load feed.';
+        errorEl.style.display = 'block';
+      }
+    }
+    loadFeed();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create `index.html` with JavaScript that fetches `data.json`, displays listings, and shows a derived "Last updated" timestamp
- Add minimal error message UI when the feed cannot be loaded
- Document GitHub Pages URL and deployment workflow in `README.md`

## Testing
- `python -m py_compile feed.py scrapers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a967fe78b88329812b3272b93bc4cb