### PR TITLE
Limit feed to latest items

### DIFF
--- a/feed.py
+++ b/feed.py
@@ -18,6 +18,8 @@ import schedule
 from scrapers import scrape_ebay
 
 DATA_FILE = Path("data.json")
+# Maximum number of items to keep in the feed
+MAX_ITEMS = 200
 
 
 def load_data() -> List[Dict[str, str]]:
@@ -43,6 +45,9 @@ def scrape_once() -> List[Dict[str, str]]:
             new_items.append(item)
 
     data.sort(key=lambda x: x.get("date"), reverse=True)
+    # Keep only the most recent MAX_ITEMS entries
+    if len(data) > MAX_ITEMS:
+        data = data[:MAX_ITEMS]
     save_data(data)
     return new_items
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
   <ul id="feed"></ul>
   <p id="error" style="display:none"></p>
   <script>
+    const MAX_ITEMS = 200;
+
     async function loadFeed() {
       const errorEl = document.getElementById('error');
       const lastUpdatedEl = document.getElementById('last-updated');
@@ -24,12 +26,15 @@
           throw new Error('Network response was not ok');
         }
         const data = await resp.json();
-        if (data.length > 0) {
-          const lastUpdated = data.reduce((max, item) => {
+        const items = data.slice(0, MAX_ITEMS);
+        if (items.length > 0) {
+          const lastUpdated = items.reduce((max, item) => {
             return item.fetched_at && item.fetched_at > max ? item.fetched_at : max;
-          }, data[0].fetched_at || '');
-          lastUpdatedEl.textContent = 'Last updated: ' + (lastUpdated ? new Date(lastUpdated).toLocaleString() : 'n/a');
-          data.forEach(item => {
+          }, items[0].fetched_at || '');
+          lastUpdatedEl.textContent = 'Last updated: ' +
+            (lastUpdated ? new Date(lastUpdated).toLocaleString() : 'n/a') +
+            ` (showing up to ${MAX_ITEMS} items)`;
+          items.forEach(item => {
             const li = document.createElement('li');
             const price = item.price ? ` – ${item.price}` : '';
             li.innerHTML = `<a href="${item.url}">${item.title}</a>${price}`;


### PR DESCRIPTION
## Summary
- add MAX_ITEMS constant to cap feed history at 200 entries
- trim stored data after scraping to retain only newest items
- web frontend now shows up to MAX_ITEMS items and notes limit

## Testing
- `python -m py_compile feed.py`
- `python -m py_compile scrapers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a97110ea548329b61c3b40f1e09501